### PR TITLE
refactor(storybook): add common size select

### DIFF
--- a/packages/react/src/components/menu.tsx
+++ b/packages/react/src/components/menu.tsx
@@ -25,10 +25,10 @@ import {
   DropdownItem,
   DropdownTrigger,
 } from "./dropdown";
+import useTheme from "./use-theme";
 
 const DefaultValue = {
   orientation: "horizontal",
-  size: "small",
 } as const;
 
 const menuVariants = cva("menu", {
@@ -48,11 +48,11 @@ const MenuContext = React.createContext<{
   size?: "small" | "medium" | "large";
 }>({
   orientation: DefaultValue.orientation,
-  size: DefaultValue.size,
+  size: undefined,
 });
 
 const Menu = React.forwardRef<
-  React.ElementRef<typeof ToggleGroupPrimitive.Root>,
+  React.ComponentRef<typeof ToggleGroupPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Root> & {
     orientation?: "vertical" | "horizontal";
     size?: "small" | "medium" | "large";
@@ -61,23 +61,26 @@ const Menu = React.forwardRef<
   (
     {
       orientation = DefaultValue.orientation,
-      size = DefaultValue.size,
+      size,
       children,
       className,
       ...props
     },
     ref,
-  ) => (
-    <ToggleGroupPrimitive.Root
-      ref={ref}
-      className={cn(menuVariants({ orientation, className }))}
-      {...props}
-    >
-      <MenuContext.Provider value={{ orientation, size }}>
-        {children}
-      </MenuContext.Provider>
-    </ToggleGroupPrimitive.Root>
-  ),
+  ) => {
+    const { themeSize } = useTheme();
+    return (
+      <ToggleGroupPrimitive.Root
+        ref={ref}
+        className={cn(menuVariants({ orientation, className }))}
+        {...props}
+      >
+        <MenuContext.Provider value={{ orientation, size: size ?? themeSize }}>
+          {children}
+        </MenuContext.Provider>
+      </ToggleGroupPrimitive.Root>
+    );
+  },
 );
 Menu.displayName = ToggleGroupPrimitive.Root.displayName;
 
@@ -89,16 +92,16 @@ const menuItemVariants = cva("menu-item", {
       large: "menu-item-large",
     },
     defaultVariants: {
-      size: DefaultValue.size,
+      size: undefined,
     },
   },
 });
 
 const MenuItem = React.forwardRef<
-  React.ElementRef<typeof ToggleGroupPrimitive.Item>,
+  React.ComponentRef<typeof ToggleGroupPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Item>
 >(({ children, className, ...props }, ref) => {
-  const { size = DefaultValue.size } = React.useContext(MenuContext);
+  const { size } = React.useContext(MenuContext);
   return (
     <ToggleGroupPrimitive.Item
       ref={ref}
@@ -114,10 +117,10 @@ MenuItem.displayName = ToggleGroupPrimitive.Item.displayName;
 const MenuDropdown = Dropdown;
 
 const MenuDropdownTrigger = React.forwardRef<
-  React.ElementRef<typeof DropdownTrigger>,
+  React.ComponentRef<typeof DropdownTrigger>,
   React.ComponentPropsWithoutRef<typeof DropdownTrigger>
 >(({ className, children, ...props }, ref) => {
-  const { size = DefaultValue.size } = React.useContext(MenuContext);
+  const { size } = React.useContext(MenuContext);
 
   if (props.asChild) {
     return (
@@ -150,7 +153,7 @@ MenuDropdownTrigger.displayName = "MenuDropdownTrigger";
 const MenuDropdownContent = DropdownContent;
 const MenuDropdownGroup = DropdownGroup;
 const MenuDropdownItem = React.forwardRef<
-  React.ElementRef<typeof DropdownItem>,
+  React.ComponentRef<typeof DropdownItem>,
   React.ComponentPropsWithoutRef<typeof MenuItem>
 >(({ className, ...props }, ref) => (
   <DropdownItem ref={ref} className={cn("menu-dropdown-item", className)}>

--- a/packages/react/src/components/multi-select.tsx
+++ b/packages/react/src/components/multi-select.tsx
@@ -17,7 +17,7 @@ import * as React from "react";
 import { Slot, Slottable } from "@radix-ui/react-slot";
 import { cva } from "class-variance-authority";
 
-import type { Size } from "../types";
+import type { Radius, Size } from "../types";
 import { ICON_SIZE } from "../constants";
 import { cn } from "../lib/utils";
 import { Icon } from "./icon";
@@ -31,7 +31,7 @@ type MultiSelectItemType = { value: string; label: React.ReactNode };
 type MultiSelectContextType = {
   disabled: boolean;
   size: Size;
-  setSize?: (size: Size) => void;
+  radius: Radius;
   selectedItems: MultiSelectItemType[];
   setSelectedItems: (items: MultiSelectItemType[]) => void;
   isOpen: boolean;
@@ -59,6 +59,7 @@ interface MultiSelectProps {
   children: React.ReactNode;
   className?: string;
   size?: Size;
+  radius?: Radius;
   disabled?: boolean;
 }
 
@@ -81,13 +82,13 @@ const MultiSelect = React.forwardRef<HTMLDivElement, MultiSelectProps>(
       onValueChange,
       children,
       className,
-      size: propSize,
+      size,
+      radius,
       disabled = false,
     },
     ref,
   ) {
-    const { themeSize } = useTheme();
-    const [size, setSize] = React.useState<Size | undefined>(propSize);
+    const { themeSize, themeRadius } = useTheme();
 
     const [registeredItems, setRegisteredItems] = React.useState<
       MultiSelectItemType[]
@@ -152,8 +153,8 @@ const MultiSelect = React.forwardRef<HTMLDivElement, MultiSelectProps>(
       <MultiSelectContext.Provider
         value={{
           disabled,
-          size: size ?? propSize ?? themeSize,
-          setSize,
+          size: size ?? themeSize,
+          radius: radius ?? themeRadius,
           selectedItems,
           setSelectedItems: (items) => setValues(items.map((i) => i.value)),
           isOpen,
@@ -168,7 +169,10 @@ const MultiSelect = React.forwardRef<HTMLDivElement, MultiSelectProps>(
           <div
             ref={ref}
             className={cn(
-              selectVariants({ size: size ?? themeSize, className }),
+              selectVariants({
+                size: size ?? themeSize,
+                className,
+              }),
             )}
           >
             {children}
@@ -191,8 +195,13 @@ const selectTriggerVariants = cva("select-trigger", {
       medium: "select-trigger-medium",
       large: "select-trigger-large",
     },
+    radius: {
+      small: "select-trigger-radius-small",
+      medium: "select-trigger-radius-medium",
+      large: "select-trigger-radius-large",
+    },
   },
-  defaultVariants: { size: undefined },
+  defaultVariants: { size: undefined, radius: undefined },
 });
 
 const MultiSelectTrigger = React.forwardRef<
@@ -218,13 +227,13 @@ const MultiSelectTriggerButton = React.forwardRef<
   HTMLButtonElement,
   MultiSelectTriggerButtonProps
 >(function MultiSelectTrigger({ className, children, ...props }, ref) {
-  const { size, disabled } = useMultiSelectContext();
+  const { size, radius, disabled } = useMultiSelectContext();
   return (
     <button
       ref={ref}
       type="button"
       aria-haspopup="listbox"
-      className={cn(selectTriggerVariants({ size, className }))}
+      className={cn(selectTriggerVariants({ size, radius, className }))}
       data-placeholder
       disabled={disabled}
       {...props}

--- a/packages/react/src/components/pagination.tsx
+++ b/packages/react/src/components/pagination.tsx
@@ -19,33 +19,31 @@ import type { ButtonProps } from "./button";
 import { cn } from "../lib/utils";
 import { Button } from "./button";
 import { Icon } from "./icon";
+import useTheme from "./use-theme";
 
-const DefaultValue = {
-  size: "small",
-  radius: "medium",
-} as const;
 const PaginationContext = React.createContext<ButtonProps>({
-  size: DefaultValue.size,
-  radius: DefaultValue.radius,
+  size: undefined,
+  radius: undefined,
 });
 
 type PaginationProps = React.ComponentProps<"nav"> &
   Pick<ButtonProps, "size" | "radius">;
-const Pagination = ({
-  size = DefaultValue.size,
-  radius = DefaultValue.radius,
-  className,
-  ...props
-}: PaginationProps) => (
-  <PaginationContext.Provider value={{ size, radius }}>
-    <nav
-      role="navigation"
-      aria-label="pagination"
-      className={cn("pagination", className)}
-      {...props}
-    />
-  </PaginationContext.Provider>
-);
+const Pagination = ({ size, radius, className, ...props }: PaginationProps) => {
+  const { themeSize, themeRadius } = useTheme();
+
+  return (
+    <PaginationContext.Provider
+      value={{ size: size ?? themeSize, radius: radius ?? themeRadius }}
+    >
+      <nav
+        role="navigation"
+        aria-label="pagination"
+        className={cn("pagination", className)}
+        {...props}
+      />
+    </PaginationContext.Provider>
+  );
+};
 Pagination.displayName = "Pagination";
 
 const PaginationContent = React.forwardRef<
@@ -77,8 +75,8 @@ const PaginationLink = ({
   return (
     <Button
       variant={isActive ? "outline" : "ghost"}
-      size={size ?? DefaultValue.size}
-      radius={radius ?? DefaultValue.radius}
+      size={size}
+      radius={radius}
       className={cn("pagination-link", className)}
       asChild
     >
@@ -96,8 +94,8 @@ const PaginationPrevious = ({
   return (
     <Button
       variant="ghost"
-      size={size ?? DefaultValue.size}
-      radius={radius ?? DefaultValue.radius}
+      size={size}
+      radius={radius}
       aria-label="Go to previous page"
       className={cn("pagination-previous", className)}
       asChild
@@ -119,8 +117,8 @@ const PaginationNext = ({
   return (
     <Button
       variant="ghost"
-      size={size ?? DefaultValue.size}
-      radius={radius ?? DefaultValue.radius}
+      size={size}
+      radius={radius}
       aria-label="Go to next page"
       className={cn("pagination-next", className)}
       asChild
@@ -144,8 +142,8 @@ const PaginationEllipsis = ({
       {...props}
       variant="ghost"
       aria-label="More Pages"
-      size={size ?? DefaultValue.size}
-      radius={radius ?? DefaultValue.radius}
+      size={size}
+      radius={radius}
       className={cn("pagination-ellipsis", className)}
     >
       <Icon name="RiMoreLine" />

--- a/packages/react/src/components/select.tsx
+++ b/packages/react/src/components/select.tsx
@@ -18,14 +18,14 @@ import * as SelectPrimitive from "@radix-ui/react-select";
 import { Slottable } from "@radix-ui/react-slot";
 import { cva } from "class-variance-authority";
 
-import type { Size } from "../lib/types";
+import type { Radius, Size } from "../lib/types";
 import { ICON_SIZE } from "../constants";
 import { cn } from "../lib/utils";
 import { Icon } from "./icon";
 import { ScrollArea, ScrollBar } from "./scroll-area";
 import useTheme from "./use-theme";
 
-type SelectContextType = { size: Size };
+type SelectContextType = { size: Size; radius: Radius };
 
 const SelectContext = React.createContext<SelectContextType | undefined>(
   undefined,
@@ -40,6 +40,7 @@ interface SelectProps
   extends React.ComponentPropsWithoutRef<typeof SelectPrimitive.Root> {
   className?: string;
   size?: Size;
+  radius?: Radius;
 }
 
 const selectVariants = cva("select", {
@@ -53,10 +54,12 @@ const selectVariants = cva("select", {
   },
 });
 
-const Select = ({ size, className, ...props }: SelectProps) => {
-  const { themeSize } = useTheme();
+const Select = ({ size, radius, className, ...props }: SelectProps) => {
+  const { themeSize, themeRadius } = useTheme();
   return (
-    <SelectContext.Provider value={{ size: size ?? themeSize }}>
+    <SelectContext.Provider
+      value={{ size: size ?? themeSize, radius: radius ?? themeRadius }}
+    >
       <div
         className={cn(selectVariants({ size: size ?? themeSize, className }))}
       >
@@ -77,8 +80,13 @@ const selectTriggerVariants = cva("select-trigger", {
       medium: "select-trigger-medium",
       large: "select-trigger-large",
     },
+    radius: {
+      small: "select-trigger-radius-small",
+      medium: "select-trigger-radius-medium",
+      large: "select-trigger-radius-large",
+    },
   },
-  defaultVariants: { size: undefined },
+  defaultVariants: { size: undefined, radius: undefined },
 });
 
 interface SelectTriggerProps
@@ -88,12 +96,12 @@ const SelectTrigger = React.forwardRef<
   React.ComponentRef<typeof SelectPrimitive.Trigger>,
   SelectTriggerProps
 >(({ className, children, ...props }, ref) => {
-  const { size } = useSelectContext();
+  const { size, radius } = useSelectContext();
 
   return (
     <SelectPrimitive.Trigger
       ref={ref}
-      className={cn(selectTriggerVariants({ size, className }))}
+      className={cn(selectTriggerVariants({ size, radius, className }))}
       {...props}
     >
       <Slottable>{children}</Slottable>

--- a/packages/tailwindcss/src/components/select.css
+++ b/packages/tailwindcss/src/components/select.css
@@ -29,10 +29,10 @@
   --select-bg: var(--bg-neutral-primary);
   --select-bg-pressed: var(--bg-neutral-tertiary);
 
-  @apply rounded-8 before:rounded-8 relative flex w-full items-center justify-start bg-[var(--select-bg)] text-left text-[var(--select-fg-filled)] transition-transform before:absolute before:inset-0 before:flex before:border before:border-[var(--select-border)] focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 data-[placeholder]:text-[var(--select-fg)] data-[state=open]:text-[var(--select-fg-pressed)] data-[state=open]:before:border-2 data-[state=open]:before:border-[var(--select-border-pressed)] [&>span]:flex [&>span]:flex-1 [&>span]:items-center [&>span]:overflow-hidden [&>svg:last-of-type]:data-[state=open]:rotate-180;
+  @apply relative flex w-full items-center justify-start bg-[var(--select-bg)] text-left text-[var(--select-fg-filled)] transition-transform before:absolute before:inset-0 before:flex before:border before:border-[var(--select-border)] focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 data-[placeholder]:text-[var(--select-fg)] data-[state=open]:text-[var(--select-fg-pressed)] data-[state=open]:before:border-2 data-[state=open]:before:border-[var(--select-border-pressed)] [&>span]:flex [&>span]:flex-1 [&>span]:items-center [&>span]:overflow-hidden [&>svg:last-of-type]:data-[state=open]:rotate-180;
 
   /* default */
-  @apply select-trigger-medium;
+  @apply select-trigger-medium select-trigger-radius-medium;
 }
 
 .select-trigger[aria-invalid="true"] {

--- a/packages/tailwindcss/src/utilities/select.css
+++ b/packages/tailwindcss/src/utilities/select.css
@@ -36,6 +36,18 @@
   @apply text-xlarge-normal min-h-13 space-x-3 px-4;
 }
 
+.select-trigger-radius-small {
+  @apply rounded-0 before:rounded-0;
+}
+
+.select-trigger-radius-medium {
+  @apply rounded-8 before:rounded-8;
+}
+
+.select-trigger-radius-large {
+  @apply rounded-full before:rounded-full;
+}
+
 .select-item-left {
   @apply pl-8 pr-2;
 }

--- a/storybooks/react-storybook/src/alert.stories.tsx
+++ b/storybooks/react-storybook/src/alert.stories.tsx
@@ -99,7 +99,6 @@ const meta: Meta<
   ],
   args: {
     variant: "default",
-    radius: undefined,
     [Props.AlertIcon.name]: undefined,
     [Props.AlertIcon.size]: 20,
     [Props.AlertButton.show]: true,
@@ -127,20 +126,6 @@ const meta: Meta<
       },
       control: "select",
       options: ["default", "warning", "success", "error", "informative"],
-    },
-    radius: {
-      description: "Set the radius of the Alert.",
-      table: {
-        category: "Alert",
-        type: {
-          summary: "large | medium | small | undefined",
-        },
-        defaultValue: {
-          summary: undefined,
-        },
-      },
-      control: "select",
-      options: ["large", "medium", "small", undefined],
     },
     [Props.AlertIcon.name]: {
       description: "Set the name of the AlertIcon.",
@@ -276,6 +261,7 @@ const meta: Meta<
       },
       control: "text",
     },
+    radius: { table: { disable: true } },
   },
   render: (args) => (
     <Alert variant={args.variant} radius={args.radius}>

--- a/storybooks/react-storybook/src/badge.stories.tsx
+++ b/storybooks/react-storybook/src/badge.stories.tsx
@@ -23,7 +23,6 @@ const meta: Meta<typeof Badge> = {
   args: {
     variant: "bold",
     color: "default",
-    radius: undefined,
     children: "Label",
   },
   argTypes: {
@@ -55,20 +54,6 @@ const meta: Meta<typeof Badge> = {
       control: "radio",
       options: ["default", "blue", "orange", "red", "green"],
     },
-    radius: {
-      description: "Set the radius of the Badge.",
-      table: {
-        category: "Badge",
-        type: {
-          summary: "large | medium | small | undefined",
-        },
-        defaultValue: {
-          summary: undefined,
-        },
-      },
-      control: "select",
-      options: ["large", "medium", "small", undefined],
-    },
     children: {
       description: "Set the children of the Badge.",
       table: {
@@ -79,11 +64,8 @@ const meta: Meta<typeof Badge> = {
       },
       control: "text",
     },
-    asChild: {
-      table: {
-        disable: true,
-      },
-    },
+    radius: { table: { disable: true } },
+    asChild: { table: { disable: true } },
   },
 };
 

--- a/storybooks/react-storybook/src/button.stories.tsx
+++ b/storybooks/react-storybook/src/button.stories.tsx
@@ -22,41 +22,11 @@ const meta: Meta<typeof Button> = {
   component: Button,
   args: {
     variant: "primary",
-    size: undefined,
-    radius: undefined,
     loading: false,
     disabled: false,
     children: "Button",
   },
   argTypes: {
-    size: {
-      description: "Set the size of the Button.",
-      table: {
-        category: "Button",
-        type: {
-          summary: "large | medium | small | undefined",
-        },
-        defaultValue: {
-          summary: undefined,
-        },
-      },
-      control: "select",
-      options: ["large", "medium", "small", undefined],
-    },
-    radius: {
-      description: "Set the radius of the Button.",
-      table: {
-        category: "Button",
-        type: {
-          summary: "large | medium | small | undefined",
-        },
-        defaultValue: {
-          summary: undefined,
-        },
-      },
-      control: "select",
-      options: ["large", "medium", "small", undefined],
-    },
     variant: {
       description: "Set the variant of the Button.",
       table: {
@@ -107,6 +77,16 @@ const meta: Meta<typeof Button> = {
       },
     },
     type: {
+      table: {
+        disable: true,
+      },
+    },
+    size: {
+      table: {
+        disable: true,
+      },
+    },
+    radius: {
       table: {
         disable: true,
       },

--- a/storybooks/react-storybook/src/checkbox.stories.tsx
+++ b/storybooks/react-storybook/src/checkbox.stories.tsx
@@ -21,26 +21,11 @@ const meta: Meta<typeof Checkbox> = {
   title: "Checkbox",
   component: Checkbox,
   args: {
-    size: "small",
     checked: undefined,
     disabled: false,
     children: "Label",
   },
   argTypes: {
-    size: {
-      description: "Set the size of the Checkbox.",
-      table: {
-        category: "Checkbox",
-        type: {
-          summary: "large | medium | small",
-        },
-        defaultValue: {
-          summary: "small",
-        },
-      },
-      control: "radio",
-      options: ["large", "medium", "small"],
-    },
     checked: {
       description: "Set the checked state of the Checkbox.",
       table: {
@@ -74,6 +59,11 @@ const meta: Meta<typeof Checkbox> = {
         },
       },
       control: "boolean",
+    },
+    size: {
+      table: {
+        disable: true,
+      },
     },
   },
 };

--- a/storybooks/react-storybook/src/component-list.mdx
+++ b/storybooks/react-storybook/src/component-list.mdx
@@ -82,7 +82,7 @@ import ThemeSelect from "./utils/themeSelect.tsx";
     additionalActions={[{ title: "Combobox" }]}
   />
   <Canvas
-    of={DialogStories.Basic}
+    of={DialogStories.Default}
     sourceState="none"
     additionalActions={[{ title: "Dialog" }]}
     layout="centered"
@@ -129,7 +129,7 @@ import ThemeSelect from "./utils/themeSelect.tsx";
     layout="centered"
   />
   <Canvas
-    of={SheetStories.Right}
+    of={SheetStories.Default}
     sourceState="none"
     additionalActions={[{ title: "Sheet" }]}
     layout="centered"
@@ -168,7 +168,7 @@ import ThemeSelect from "./utils/themeSelect.tsx";
     layout="centered"
   />
   <Canvas
-    of={TagStories.Basic}
+    of={TagStories.Default}
     sourceState="none"
     additionalActions={[{ title: "Tag" }]}
     layout="centered"

--- a/storybooks/react-storybook/src/dialog.stories.tsx
+++ b/storybooks/react-storybook/src/dialog.stories.tsx
@@ -177,7 +177,7 @@ const meta: Meta<
     },
   },
   render: (args) => (
-    <Dialog defaultOpen>
+    <Dialog>
       <DialogTrigger>Open</DialogTrigger>
       <DialogContent>
         <DialogHeader>
@@ -224,38 +224,6 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
-
-export const Basic = () => (
-  <Dialog>
-    <DialogTrigger>Open</DialogTrigger>
-    <DialogContent>
-      <DialogHeader>
-        <DialogIcon name="RiFlashlightFill" variant="default" />
-        <DialogTitle>Title</DialogTitle>
-        <DialogDescription>Description</DialogDescription>
-      </DialogHeader>
-      <DialogBody>
-        <InputField>
-          <Label>Label</Label>
-          <TextInput size="small" />
-        </InputField>
-        <InputField>
-          <Label>Label</Label>
-          <TextInput size="small" />
-          <Caption variant="info">
-            Lorem ipsum dolor sit amet consectetur, adipisicing elit.
-          </Caption>
-        </InputField>
-      </DialogBody>
-      <DialogFooter>
-        <DialogClose onClick={() => alert("clicked!")}>Button</DialogClose>
-        <DialogClose variant="primary" onClick={() => alert("clicked!")}>
-          Button
-        </DialogClose>
-      </DialogFooter>
-    </DialogContent>
-  </Dialog>
-);
 
 export const Warning = () => (
   <Dialog>

--- a/storybooks/react-storybook/src/input.stories.tsx
+++ b/storybooks/react-storybook/src/input.stories.tsx
@@ -123,21 +123,9 @@ const meta: Meta<
       control: "select",
       options: IconNames,
     },
-    radius: {
-      table: {
-        disable: true,
-      },
-    },
-    size: {
-      table: {
-        disable: true,
-      },
-    },
-    type: {
-      table: {
-        disable: true,
-      },
-    },
+    radius: { table: { disable: true } },
+    size: { table: { disable: true } },
+    type: { table: { disable: true } },
   },
   decorators: (Story) => <Story />,
   render: (args) => {

--- a/storybooks/react-storybook/src/multiSelect.stories.tsx
+++ b/storybooks/react-storybook/src/multiSelect.stories.tsx
@@ -94,23 +94,12 @@ const meta: Meta<
     </MultiSelect>
   ),
   args: {
-    size: undefined,
     disabled: false,
     [Props.MultiSelectValue.placeholder]: "Select a fruit...",
     [Props.MultiSelectContent.maxHeight]: "auto",
     [Props.MultiSelectItem.children]: "Custom",
   },
   argTypes: {
-    size: {
-      description: "Set the size of the Select.",
-      table: {
-        category: "MultiSelect",
-        type: { summary: "large | medium | small | undefined" },
-        defaultValue: { summary: undefined },
-      },
-      control: "select",
-      options: ["large", "medium", "small", undefined],
-    },
     disabled: {
       description: "Set whether the Select is in an disabled state.",
       table: { category: "MultiSelect", defaultValue: { summary: "false" } },
@@ -138,6 +127,7 @@ const meta: Meta<
     defaultValue: { table: { disable: true } },
     onValueChange: { table: { disable: true } },
     children: { table: { disable: true } },
+    size: { table: { disable: true } },
   },
 };
 

--- a/storybooks/react-storybook/src/multiSelect.stories.tsx
+++ b/storybooks/react-storybook/src/multiSelect.stories.tsx
@@ -128,6 +128,7 @@ const meta: Meta<
     onValueChange: { table: { disable: true } },
     children: { table: { disable: true } },
     size: { table: { disable: true } },
+    radius: { table: { disable: true } },
   },
 };
 

--- a/storybooks/react-storybook/src/pagination.stories.tsx
+++ b/storybooks/react-storybook/src/pagination.stories.tsx
@@ -29,16 +29,8 @@ const meta: Meta<typeof Pagination> = {
   title: "Pagination",
   component: Pagination,
   argTypes: {
-    size: {
-      table: {
-        disable: true,
-      },
-    },
-    radius: {
-      table: {
-        disable: true,
-      },
-    },
+    radius: { table: { disable: true } },
+    size: { table: { disable: true } },
   },
   render: (props) => (
     <Pagination {...props}>

--- a/storybooks/react-storybook/src/select.stories.tsx
+++ b/storybooks/react-storybook/src/select.stories.tsx
@@ -133,6 +133,7 @@ const meta: Meta<
     className: { table: { disable: true } },
     value: { table: { disable: true } },
     size: { table: { disable: true } },
+    radius: { table: { disable: true } },
   },
 };
 

--- a/storybooks/react-storybook/src/select.stories.tsx
+++ b/storybooks/react-storybook/src/select.stories.tsx
@@ -94,7 +94,6 @@ const meta: Meta<
     </Select>
   ),
   args: {
-    size: undefined,
     disabled: false,
     [Props.SelectValue.placeholder]: "Select a fruit...",
     [Props.SelectContent.position]: "popper",
@@ -102,16 +101,6 @@ const meta: Meta<
     [Props.SelectItem.children]: "Custom",
   },
   argTypes: {
-    size: {
-      description: "Set the size of the Select.",
-      table: {
-        category: "Select",
-        type: { summary: "large | medium | small | undefined" },
-        defaultValue: { summary: undefined },
-      },
-      control: "select",
-      options: ["large", "medium", "small", undefined],
-    },
     disabled: {
       description: "Set whether the Select is in an disabled state.",
       table: { category: "Select", defaultValue: { summary: "false" } },
@@ -143,6 +132,7 @@ const meta: Meta<
     },
     className: { table: { disable: true } },
     value: { table: { disable: true } },
+    size: { table: { disable: true } },
   },
 };
 

--- a/storybooks/react-storybook/src/sheet.stories.tsx
+++ b/storybooks/react-storybook/src/sheet.stories.tsx
@@ -152,7 +152,7 @@ const meta: Meta<
     },
   },
   render: (args) => (
-    <Sheet defaultOpen>
+    <Sheet>
       <SheetTrigger>Trigger</SheetTrigger>
       <SheetContent side={args[Props.SheetContent.side]}>
         <SheetHeader icon={args[Props.SheetHeader.icon]}>

--- a/storybooks/react-storybook/src/tag.stories.tsx
+++ b/storybooks/react-storybook/src/tag.stories.tsx
@@ -22,8 +22,6 @@ const meta: Meta<typeof Tag> = {
   component: Tag,
   args: {
     variant: "primary",
-    size: "small",
-    radius: undefined,
     children: "Label",
   },
   argTypes: {
@@ -41,34 +39,6 @@ const meta: Meta<typeof Tag> = {
       control: "radio",
       options: ["primary", "secondary", "outline", "destructive"],
     },
-    size: {
-      description: "Set the size of the Tag.",
-      table: {
-        category: "Tag",
-        type: {
-          summary: "large | medium | small | undefined",
-        },
-        defaultValue: {
-          summary: undefined,
-        },
-      },
-      control: "select",
-      options: ["large", "medium", "small", undefined],
-    },
-    radius: {
-      description: "Set the radius of the Tag.",
-      table: {
-        category: "Tag",
-        type: {
-          summary: "large | medium | small",
-        },
-        defaultValue: {
-          summary: "small",
-        },
-      },
-      control: "select",
-      options: ["large", "medium", "small"],
-    },
     children: {
       description: "Set the children of the Tag.",
       table: {
@@ -79,11 +49,9 @@ const meta: Meta<typeof Tag> = {
       },
       control: "text",
     },
-    asChild: {
-      table: {
-        disable: true,
-      },
-    },
+    asChild: { table: { disable: true } },
+    radius: { table: { disable: true } },
+    size: { table: { disable: true } },
   },
 };
 

--- a/storybooks/react-storybook/src/tag.stories.tsx
+++ b/storybooks/react-storybook/src/tag.stories.tsx
@@ -61,14 +61,6 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
 
-export const Basic = () => (
-  <Tag size="small" radius="medium" variant="primary">
-    <Icon name="RiFlashlightFill" />
-    Label
-    <Icon name="RiCloseLargeLine" onClick={() => alert("clicked")} />
-  </Tag>
-);
-
 export const Primary = () => (
   <div className="grid grid-cols-[repeat(4,max-content)] gap-2">
     <Tag size="small" radius="medium" variant="primary">

--- a/storybooks/react-storybook/src/utils/themeSelect.tsx
+++ b/storybooks/react-storybook/src/utils/themeSelect.tsx
@@ -45,6 +45,11 @@ export default function ThemeSelect() {
     forceReRender(`radius:${radius}`);
   };
 
+  const handleChangeSize = (size: string) => {
+    setSize(size);
+    forceReRender(`size:${size}`);
+  };
+
   const getDocumentDark = () =>
     document.documentElement.classList.contains("dark") ? "dark" : "light";
 
@@ -216,23 +221,19 @@ export default function ThemeSelect() {
           </SelectGroup>
         </SelectContent>
       </Select>
-      {/* <div>
-        Rounded Base
-        <TextInput
-          type="number"
-          defaultValue={parseInt(
-            document.documentElement.style.getPropertyValue("--rounded-base") ||
-              "0",
-          )}
-          onChange={(e) => {
-            const number = Number(e.target.value);
-            document.documentElement.style.setProperty(
-              "--rounded-base",
-              number + "px",
-            );
-          }}
-        />
-      </div> */}
+      <Select size="small" value={size} onValueChange={handleChangeSize}>
+        <Label>Size</Label>
+        <SelectTrigger>
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent maxHeight="auto" position="popper">
+          <SelectGroup>
+            <SelectItem value="small">Small</SelectItem>
+            <SelectItem value="medium">Medium</SelectItem>
+            <SelectItem value="large">Large</SelectItem>
+          </SelectGroup>
+        </SelectContent>
+      </Select>
     </div>
   );
 }


### PR DESCRIPTION
Refactor
- remove radius and size props from multiple components
- add common size select

Fix bugs
- Pagination's Button size, radius
- Select/MultiSelect Trigger radius
- Menu size
- component list's Tag example
- remove defaultOpen Sheet, Dialog