### PR TITLE
chore(release): prepare v2.1.0

### DIFF
--- a/.changeset/release-2-1-0.md
+++ b/.changeset/release-2-1-0.md
@@ -1,0 +1,7 @@
+---
+"@line/abc-def-react": minor
+"@line/abc-def-vue": minor
+"@line/abc-def-styles": minor
+---
+
+Release internal package updates in version 2.1.0.

--- a/apps/docs/src/components/docs-layout.tsx
+++ b/apps/docs/src/components/docs-layout.tsx
@@ -107,7 +107,7 @@ function LogoSVG() {
   );
 }
 
-const VERSION = "2.0.0";
+const VERSION = "2.1.0";
 
 export function DocsLayout({ children }: DocsLayoutProps) {
   const components = getComponentsByName();


### PR DESCRIPTION
## Summary
- add a Changeset to release React, Vue, and styles packages as 2.1.0
- update the documentation version badge to 2.1.0

## Validation
- pnpm changeset status
- pnpm format
- pnpm lint
- pnpm typecheck
- pnpm build