### PR TITLE
Fix styles for Reka variable compatibility

### DIFF
--- a/examples/nextjs/next-env.d.ts
+++ b/examples/nextjs/next-env.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 import "./.next/dev/types/routes.d.ts";
+import "./.next/dev/types/root-params.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/examples/nextjs/src/components/select-demo.tsx
+++ b/examples/nextjs/src/components/select-demo.tsx
@@ -10,7 +10,7 @@ import {
 
 export function SelectDemo() {
   return (
-    <Select>
+    <Select open>
       <SelectTrigger className="w-full max-w-48">
         <SelectValue placeholder="Select a fruit" />
       </SelectTrigger>

--- a/packages/styles/src/components/context-menu.css
+++ b/packages/styles/src/components/context-menu.css
@@ -9,13 +9,13 @@
   --context-menu-label-fg: var(--muted-foreground);
   --context-menu-item-bg-focus: var(--accent);
   --context-menu-item-fg-focus: var(--accent-foreground);
-  --context-menu-item-fg-destructive: var(--destructive);
+  --context-menu-item-fg-destructive: var(--destructive-foreground);
   --context-menu-item-bg-destructive-focus: color-mix(
     in oklab,
     var(--destructive) 10%,
     transparent
   );
-  --context-menu-item-fg-destructive-focus: var(--destructive);
+  --context-menu-item-fg-destructive-focus: var(--destructive-foreground);
 
   --context-menu-sub-trigger-bg-focus: var(--accent);
   --context-menu-sub-trigger-fg-focus: var(--accent-foreground);
@@ -39,14 +39,23 @@
   }
 
   .context-menu-content {
-    @apply z-50 max-h-(--radix-context-menu-content-available-height) min-w-36 origin-(--radix-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg p-1;
+    --max-height: var(
+      --radix-context-menu-content-available-height,
+      var(--reka-context-menu-content-available-height)
+    );
+    --origin: var(
+      --radix-context-menu-content-transform-origin,
+      var(--reka-context-menu-content-transform-origin)
+    );
+    @apply max-h-(--max-height) origin-(--origin);
+    @apply z-50 min-w-36 overflow-x-hidden overflow-y-auto rounded-lg p-1;
     @apply bg-(--context-menu-content-bg) text-(--context-menu-content-fg) shadow-md ring-1 ring-(--context-menu-content-border) duration-100;
     @apply data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2;
     @apply data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95;
   }
 
   .context-menu-sub-content {
-    @apply z-50 min-w-32 origin-(--radix-context-menu-content-transform-origin) overflow-hidden rounded-lg border border-(--context-menu-content-border) bg-(--context-menu-content-bg) p-1 text-(--context-menu-content-fg) shadow-lg duration-100;
+    @apply z-50 min-w-32 origin-(--origin) overflow-hidden rounded-lg border border-(--context-menu-content-border) bg-(--context-menu-content-bg) p-1 text-(--context-menu-content-fg) shadow-lg duration-100;
     @apply data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2;
     @apply data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95;
   }

--- a/packages/styles/src/components/dropdown-menu.css
+++ b/packages/styles/src/components/dropdown-menu.css
@@ -9,13 +9,13 @@
   --dropdown-menu-label-fg: var(--muted-foreground);
   --dropdown-menu-item-bg-focus: var(--accent);
   --dropdown-menu-item-fg-focus: var(--accent-foreground);
-  --dropdown-menu-item-fg-destructive: var(--destructive);
+  --dropdown-menu-item-fg-destructive: var(--destructive-foreground);
   --dropdown-menu-item-bg-destructive-focus: color-mix(
     in oklab,
     var(--destructive) 10%,
     transparent
   );
-  --dropdown-menu-item-fg-destructive-focus: var(--destructive);
+  --dropdown-menu-item-fg-destructive-focus: var(--destructive-foreground);
   --dropdown-menu-separator-bg: var(--border);
   --dropdown-menu-shortcut-fg: var(--muted-foreground);
 }
@@ -30,13 +30,27 @@
 
 @layer components {
   .dropdown-menu-content {
-    @apply z-50 max-h-(--radix-dropdown-menu-content-available-height) w-(--radix-dropdown-menu-trigger-width) min-w-32 origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg border border-(--dropdown-menu-content-border) bg-(--dropdown-menu-content-bg) p-1 text-(--dropdown-menu-content-fg) shadow-md duration-100;
+    --max-height: var(
+      --radix-dropdown-menu-content-available-height,
+      var(--reka-dropdown-menu-content-available-height)
+    );
+    --width: var(
+      --radix-dropdown-menu-trigger-width,
+      var(--reka-dropdown-menu-trigger-width)
+    );
+    --origin: var(
+      --radix-dropdown-menu-content-transform-origin,
+      var(--reka-dropdown-menu-content-transform-origin)
+    );
+    @apply max-h-(--max-height) w-(--width) origin-(--origin);
+    @apply border-(--dropdown-menu-content-border) bg-(--dropdown-menu-content-bg) text-(--dropdown-menu-content-fg);
+    @apply z-50 min-w-32 overflow-x-hidden overflow-y-auto rounded-lg border p-1 shadow-md duration-100;
     @apply data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2;
     @apply data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95;
   }
 
   .dropdown-menu-sub-content {
-    @apply z-50 min-w-24 origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-lg border border-(--dropdown-menu-content-border) bg-(--dropdown-menu-content-bg) p-1 text-(--dropdown-menu-content-fg) shadow-md duration-100;
+    @apply z-50 min-w-24 origin-(--origin) overflow-hidden rounded-lg border border-(--dropdown-menu-content-border) bg-(--dropdown-menu-content-bg) p-1 text-(--dropdown-menu-content-fg) shadow-md duration-100;
     @apply data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2;
     @apply data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95;
   }

--- a/packages/styles/src/components/input.css
+++ b/packages/styles/src/components/input.css
@@ -6,7 +6,7 @@
   --input-border: var(--border-input);
   --input-border-destructive: var(--destructive);
 
-  --input-fg-destructive: var(--destructive);
+  --input-fg-destructive: var(--destructive-foreground);
   --input-file-fg: var(--foreground);
 }
 

--- a/packages/styles/src/components/menubar.css
+++ b/packages/styles/src/components/menubar.css
@@ -14,13 +14,13 @@
   --menubar-label-fg: var(--muted-foreground);
   --menubar-item-bg-focus: var(--accent);
   --menubar-item-fg-focus: var(--accent-foreground);
-  --menubar-item-fg-destructive: var(--destructive);
+  --menubar-item-fg-destructive: var(--destructive-foreground);
   --menubar-item-bg-destructive-focus: color-mix(
     in oklab,
     var(--destructive) 10%,
     transparent
   );
-  --menubar-item-fg-destructive-focus: var(--destructive);
+  --menubar-item-fg-destructive-focus: var(--destructive-foreground);
   --menubar-separator-bg: var(--border);
   --menubar-shortcut-fg: var(--muted-foreground);
 }
@@ -45,13 +45,17 @@
   }
 
   .menubar-content {
-    @apply z-50 min-w-36 origin-(--radix-menubar-content-transform-origin) overflow-hidden rounded-lg border border-(--menubar-content-border) bg-(--menubar-content-bg) p-1 text-(--menubar-content-fg) shadow-md duration-100;
+    --origin: var(
+      --radix-menubar-content-transform-origin,
+      var(--reka-menubar-content-transform-origin)
+    );
+    @apply z-50 min-w-36 origin-(--origin) overflow-hidden rounded-lg border border-(--menubar-content-border) bg-(--menubar-content-bg) p-1 text-(--menubar-content-fg) shadow-md duration-100;
     @apply data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2;
     @apply data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95;
   }
 
   .menubar-sub-content {
-    @apply z-50 min-w-32 origin-(--radix-menubar-content-transform-origin) overflow-hidden rounded-lg border border-(--menubar-content-border) bg-(--menubar-content-bg) p-1 text-(--menubar-content-fg) shadow-md duration-100;
+    @apply z-50 min-w-32 origin-(--origin) overflow-hidden rounded-lg border border-(--menubar-content-border) bg-(--menubar-content-bg) p-1 text-(--menubar-content-fg) shadow-md duration-100;
     @apply data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2;
     @apply data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95;
   }

--- a/packages/styles/src/components/navigation-menu.css
+++ b/packages/styles/src/components/navigation-menu.css
@@ -74,8 +74,16 @@
   }
 
   .navigation-menu-viewport {
-    @apply relative mt-1.5 h-(--radix-navigation-menu-viewport-height) w-full origin-top overflow-hidden rounded-md border border-(--navigation-menu-content-border) bg-(--navigation-menu-content-bg) text-(--navigation-menu-content-fg) shadow;
-    @apply md:w-(--radix-navigation-menu-viewport-width);
+    --height: var(
+      --radix-navigation-menu-viewport-height,
+      var(--reka-navigation-menu-viewport-height)
+    );
+    --width: var(
+      --radix-navigation-menu-viewport-width,
+      var(--reka-navigation-menu-viewport-width)
+    );
+    @apply h-(--height) md:w-(--width);
+    @apply relative mt-1.5 w-full origin-top overflow-hidden rounded-md border border-(--navigation-menu-content-border) bg-(--navigation-menu-content-bg) text-(--navigation-menu-content-fg) shadow;
     @apply data-[state=open]:animate-in data-[state=open]:zoom-in-90 data-[state=closed]:animate-out data-[state=closed]:zoom-out-95;
   }
 

--- a/packages/styles/src/components/popover.css
+++ b/packages/styles/src/components/popover.css
@@ -11,8 +11,12 @@
 
 @layer components {
   .popover-content {
+    --origin: var(
+      --radix-popover-content-transform-origin,
+      var(--reka-popover-content-transform-origin)
+    );
     @apply z-50 flex w-72 flex-col gap-2.5 rounded-lg border border-(--popover-content-border) bg-(--popover-content-bg) p-2.5 text-sm text-(--popover-content-fg) shadow-md outline-hidden duration-100;
-    @apply origin-(--radix-popover-content-transform-origin);
+    @apply origin-(--origin);
     @apply data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95;
     @apply data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2;
   }

--- a/packages/styles/src/components/select.css
+++ b/packages/styles/src/components/select.css
@@ -60,7 +60,16 @@
   }
 
   .select-content {
-    @apply relative z-50 max-h-(--radix-select-content-available-height) min-w-36 origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg border border-(--select-content-border) bg-(--select-content-bg) text-(--select-content-fg) shadow-md duration-100;
+    --max-height: var(
+      --radix-select-content-available-height,
+      var(--reka-select-content-available-height)
+    );
+    --origin: var(
+      --radix-select-content-transform-origin,
+      var(--reka-select-content-transform-origin)
+    );
+    @apply max-h-(--max-height) origin-(--origin);
+    @apply relative z-50 min-w-36 overflow-x-hidden overflow-y-auto rounded-lg border border-(--select-content-border) bg-(--select-content-bg) text-(--select-content-fg) shadow-md duration-100;
     @apply data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2;
     @apply data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95;
   }
@@ -70,7 +79,15 @@
   }
 
   .select-viewport {
-    @apply data-[position=popper]:h-(--radix-select-trigger-height) data-[position=popper]:w-full data-[position=popper]:min-w-(--radix-select-trigger-width);
+    --trigger-height: var(
+      --radix-select-trigger-height,
+      var(--reka-select-trigger-height)
+    );
+    --trigger-width: var(
+      --radix-select-trigger-width,
+      var(--reka-select-trigger-width)
+    );
+    @apply data-[position=popper]:h-(--trigger-height) data-[position=popper]:w-full data-[position=popper]:min-w-(--trigger-width);
   }
 
   .select-label {

--- a/packages/styles/src/components/tooltip.css
+++ b/packages/styles/src/components/tooltip.css
@@ -6,8 +6,12 @@
 
 @layer components {
   .tooltip-content {
+    --origin: var(
+      --radix-tooltip-content-transform-origin,
+      var(--reka-tooltip-content-transform-origin)
+    );
     @apply z-50 inline-flex w-fit max-w-xs items-center gap-1.5 rounded-md bg-(--tooltip-content-bg) px-3 py-1.5 text-xs text-(--tooltip-content-fg);
-    @apply origin-(--radix-tooltip-content-transform-origin);
+    @apply origin-(--origin);
     @apply has-[[data-slot=kbd]]:pr-1.5 [&_[data-slot=kbd]]:relative [&_[data-slot=kbd]]:isolate [&_[data-slot=kbd]]:z-50 [&_[data-slot=kbd]]:rounded-sm;
     @apply data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-[state=instant-open]:animate-in data-[state=instant-open]:fade-in-0 data-[state=instant-open]:zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95;
     @apply data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2;

--- a/packages/styles/src/components/variables.css
+++ b/packages/styles/src/components/variables.css
@@ -13,7 +13,7 @@
   --alert-fg-default: var(--surface-foreground);
 
   --alert-bg-destructive: var(--surface);
-  --alert-fg-destructive: var(--destructive);
+  --alert-fg-destructive: var(--destructive-foreground);
 
   --alert-title-fg-link: var(--primary);
 
@@ -296,13 +296,13 @@
   --context-menu-label-fg: var(--muted-foreground);
   --context-menu-item-bg-focus: var(--accent);
   --context-menu-item-fg-focus: var(--accent-foreground);
-  --context-menu-item-fg-destructive: var(--destructive);
+  --context-menu-item-fg-destructive: var(--destructive-foreground);
   --context-menu-item-bg-destructive-focus: color-mix(
     in oklab,
     var(--destructive) 10%,
     transparent
   );
-  --context-menu-item-fg-destructive-focus: var(--destructive);
+  --context-menu-item-fg-destructive-focus: var(--destructive-foreground);
   --context-menu-separator-bg: var(--border);
   --context-menu-shortcut-fg: var(--muted-foreground);
 
@@ -338,13 +338,13 @@
   --dropdown-menu-label-fg: var(--muted-foreground);
   --dropdown-menu-item-bg-focus: var(--accent);
   --dropdown-menu-item-fg-focus: var(--accent-foreground);
-  --dropdown-menu-item-fg-destructive: var(--destructive);
+  --dropdown-menu-item-fg-destructive: var(--destructive-foreground);
   --dropdown-menu-item-bg-destructive-focus: color-mix(
     in oklab,
     var(--destructive) 10%,
     transparent
   );
-  --dropdown-menu-item-fg-destructive-focus: var(--destructive);
+  --dropdown-menu-item-fg-destructive-focus: var(--destructive-foreground);
   --dropdown-menu-separator-bg: var(--border);
   --dropdown-menu-shortcut-fg: var(--muted-foreground);
 
@@ -375,7 +375,7 @@
   --input-border: var(--border-input);
   --input-border-destructive: var(--destructive);
 
-  --input-fg-destructive: var(--destructive);
+  --input-fg-destructive: var(--destructive-foreground);
   --input-file-fg: var(--foreground);
 
   /* input-otp.css */
@@ -417,13 +417,13 @@
   --menubar-label-fg: var(--muted-foreground);
   --menubar-item-bg-focus: var(--accent);
   --menubar-item-fg-focus: var(--accent-foreground);
-  --menubar-item-fg-destructive: var(--destructive);
+  --menubar-item-fg-destructive: var(--destructive-foreground);
   --menubar-item-bg-destructive-focus: color-mix(
     in oklab,
     var(--destructive) 10%,
     transparent
   );
-  --menubar-item-fg-destructive-focus: var(--destructive);
+  --menubar-item-fg-destructive-focus: var(--destructive-foreground);
   --menubar-separator-bg: var(--border);
   --menubar-shortcut-fg: var(--muted-foreground);
 

--- a/packages/vue/src/components/context-menu/ContextMenuSubTrigger.vue
+++ b/packages/vue/src/components/context-menu/ContextMenuSubTrigger.vue
@@ -27,6 +27,6 @@ const forwardedProps = useForwardProps(delegatedProps);
     :class="cn('context-menu-sub-trigger', props.class)"
   >
     <slot />
-    <ChevronRightIcon />
+    <ChevronRightIcon class="cn-rtl-flip ml-auto" />
   </ContextMenuSubTrigger>
 </template>

--- a/packages/vue/src/components/dropdown-menu/DropdownMenuSubTrigger.vue
+++ b/packages/vue/src/components/dropdown-menu/DropdownMenuSubTrigger.vue
@@ -26,6 +26,6 @@ const forwardedProps = useForwardProps(delegatedProps);
     :class="cn('dropdown-menu-sub-trigger', props.class)"
   >
     <slot />
-    <ChevronRightIcon />
+    <ChevronRightIcon class="cn-rtl-flip ml-auto" />
   </DropdownMenuSubTrigger>
 </template>


### PR DESCRIPTION
## Summary
- Add Reka CSS custom-property fallbacks alongside Radix variables for menu, select, popover, tooltip, and navigation layout values.
- Use destructive foreground tokens for destructive text color variables.
- Align Vue submenu chevrons with the RTL flip utility and keep the Next select demo open for content style coverage.

## Testing
- pnpm exec turbo run lint --continue --force -- --cache --cache-location .cache/.eslintcache
- pnpm exec turbo run typecheck --force
- pnpm exec turbo run build --filter='./packages/*' --force