### PR TITLE
chore(release): prepare v2.2.0

### DIFF
--- a/.changeset/release-2-2-0.md
+++ b/.changeset/release-2-2-0.md
@@ -1,0 +1,11 @@
+---
+"@line/abc-def-react": minor
+"@line/abc-def-vue": minor
+"@line/abc-def-styles": minor
+---
+
+Prepare version 2.2.0 with accumulated component fixes and dependency updates.
+
+- Fixed Vue combobox composition and popper sizing behavior.
+- Improved style compatibility with Reka UI CSS variables across overlay components.
+- Updated React, Vue, Radix, Base UI, TanStack Vue Table, Lucide, and related build dependencies.

--- a/apps/docs/src/components/docs-layout.tsx
+++ b/apps/docs/src/components/docs-layout.tsx
@@ -107,7 +107,7 @@ function LogoSVG() {
   );
 }
 
-const VERSION = "2.1.0";
+const VERSION = "2.2.0";
 
 export function DocsLayout({ children }: DocsLayoutProps) {
   const components = getComponentsByName();


### PR DESCRIPTION
## Summary
- add a 2.2.0 changeset for the fixed public package group
- update the docs version badge to v2.2.0

## Verification
- pnpm format
- pnpm lint
- proxy pnpm typecheck
- proxy pnpm build